### PR TITLE
Fixed example; removed requirements.txt from docs and tests, and placed them into extras_require

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,3 +4,6 @@ build:
 python:
   version: 3.6
   setup_py_install: true
+  extra_requirements:
+    - tests
+    - docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ matrix:
     dist: xenial
 
 install:
-  - pip install -r tests/requirements.txt
-  - pip install .
+  pip install -e .[tests,docs]
 
 before_script: flake8
 script: tox

--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@
   <br>
 
   <a href="https://travis-ci.com/kyb3r/dhooks">
-    <img src="https://img.shields.io/travis/com/kyb3r/dhooks/master.svg?style=for-the-badge&colorB=7289DA" alt="Travis" />
+    <img src="https://img.shields.io/travis/com/kyb3r/dhooks/master.svg?style=for-the-badge&colorB=06D6A0" alt="Travis" />
+  </a>
+  
+  <a href='https://test-dhooks-doc.readthedocs.io/en/latest/?badge=latest'>
+    <img src='https://img.shields.io/readthedocs/dhooks.svg?style=for-the-badge&colorB=E8BE5D' alt='Documentation Status' />
+  </a>
+
+  <a href="https://github.com/kyb3r/dhooks/">
+    <img src="https://img.shields.io/pypi/pyversions/dhooks.svg?style=for-the-badge&colorB=F489A3" alt="Py Versions" />
   </a>
 
   <a href="https://pypi.org/project/dhooks/">
-    <img src="https://img.shields.io/pypi/pyversions/dhooks.svg?style=for-the-badge&colorB=7289DA" alt="Versions" />
-  </a>
-
-  <a href="https://pypi.org/project/dhooks/">
-    <img src="https://img.shields.io/pypi/v/dhooks.svg?style=for-the-badge&colorB=7289DA" alt="PyPi" />
+    <img src="https://img.shields.io/pypi/v/dhooks.svg?style=for-the-badge&colorB=61829F" alt="PyPi" />
   </a>
 
   <a href="https://pypi.org/project/dhooks/">
@@ -34,17 +38,25 @@
 
 ## Installation
 
-To install the library simply use [pipenv](http://pipenv.org/) (or pip, of course).
+To install the library simply use pip.
 
+
+```commandline
+pip install dhooks
 ```
-pipenv install dhooks
+
+If you would also like to build the docs or run tests, you may want to install
+dhooks with the optional extended dependencies.
+
+```commandline
+pip install dhooks[tests,docs]
 ```
 
 ## Quick Start
 
 ### Sending Messages:
 
-```py
+```python
 from dhooks import Webhook
 
 hook = Webhook('url')
@@ -62,7 +74,7 @@ You can easily format and send embeds using this library.
 
 Note: `Embed` objects from `discord.py` are also compatible with this library.
 
-```py
+```python
 from dhooks import Webhook, Embed
 
 hook = Webhook('url')
@@ -91,7 +103,7 @@ hook.send(embeds=embed)
 
 You can easily send files as shown.
 
-```py
+```python
 from dhooks import Webhook, File
 from io import BytesIO
 import requests
@@ -105,7 +117,7 @@ hook.send('Look at this:', file=file)
 
 You can also pass a file-like object:
 
-```py
+```python
 response = requests.get('https://i.imgur.com/rdm3W9t.png')
 file = File(BytesIO(response.content), name='wow.png')
 
@@ -116,7 +128,7 @@ hook.send('Another one:', file=file)
 
 You can get some basic information related to the webhook through Discord's API.
 
-```py
+```python
 hook.get_info()
 ```
 
@@ -131,7 +143,7 @@ The following attributes will be populated with data from discord:
 ### Modify and Delete Webhooks:
 You can change the default name and avatar of a webhook easily.
 
-```py
+```python
 with open('img.png', rb) as f:
     img = f.read()  # bytes
 
@@ -144,7 +156,7 @@ hook.delete()  # webhook deleted permanently
 
 To asynchronously make requests using `aiohttp`, simply use `Webhook.Async` to create the object. An example is as follows. Simply use the `await` keyword when calling API methods.
 
-```py
+```python
 from dhooks import Webhook
 
 async def main():
@@ -159,7 +171,7 @@ async def main():
 ```
 
 Alternatively you can use an `async with` block (asynchronous context manager) to automatically close the session once finished.
-```py
+```python
 async def main():
     async with Webhook.Async('url') as hook:
         await hook.send('hello')

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ To install the library simply use pip.
 pip install dhooks
 ```
 
-If you would also like to build the docs or run tests, you may want to install
+If you would also like to get the latest version of dhooks from GitHub, build docs, run tests or run examples, you may want to install
 dhooks with the optional extended dependencies.
 
 ```commandline
-pip install dhooks[tests,docs]
+git clone https://github.com/kyb3r/dhooks.git
+cd dhooks
+pip install .[tests,docs,examples]
 ```
 
 ## Quick Start

--- a/dhooks/utils.py
+++ b/dhooks/utils.py
@@ -16,7 +16,7 @@ def copy_func(f):
 def alias(*aliases):
     def decorator(func):
         new_func = copy_func(func)
-        new_func.__doc__ = 'Alias for :meth:`{0.__name__}.`'.format(func)
+        new_func.__doc__ = 'Alias for :meth:`{0.__name__}`.'.format(func)
         func._aliases = {a: new_func for a in aliases}
         return func
     return decorator

--- a/dhooks/utils.py
+++ b/dhooks/utils.py
@@ -16,7 +16,7 @@ def copy_func(f):
 def alias(*aliases):
     def decorator(func):
         new_func = copy_func(func)
-        new_func.__doc__ = 'Alias for :meth:`{0.__name__}`'.format(func)
+        new_func.__doc__ = 'Alias for :meth:`{0.__name__}.`'.format(func)
         func._aliases = {a: new_func for a in aliases}
         return func
     return decorator

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,8 @@ extensions = [
     'sphinx.ext.napoleon'
 ]
 
+rst_epilog = ""
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -59,7 +61,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-sphinx_rtd_theme
-sphinx
-aiohttp==2.3.10
-dhooks

--- a/examples/async.py
+++ b/examples/async.py
@@ -1,5 +1,4 @@
-# Asynchronous example usecase with sanic (Dummy app)
-import os
+# Asynchronous example with Sanic
 import socket
 
 import aiohttp
@@ -7,47 +6,56 @@ from sanic import Sanic, response
 
 from dhooks import Webhook, Embed
 
+###
+webhook_url = "<INSERT WEBHOOK URL HERE>"
+###
+
 app = Sanic(__name__)
 
 
 @app.listener('before_server_start')
 async def init(app, loop):
-    """Sends a message to the webhook channel when server stops"""
+    """Sends a message to the webhook channel when server starts."""
     app.session = aiohttp.ClientSession(loop=loop)  # to make web requests
-    app.webhook = Webhook.Async(
-        os.getenv('webhook_url'),
-        session=app.session
-    )
+    app.webhook = Webhook.Async(webhook_url, session=app.session)
 
     em = Embed(color=0x2ecc71)
     em.set_author('[INFO] Starting Worker')
-    em.set_footer('Host: {}'.format(socket.gethostname()))
+    em.description = 'Host: {}'.format(socket.gethostname())
 
-    await app.webhook.send(embeds=em)
+    await app.webhook.send(embed=em)
 
 
 @app.listener('after_server_stop')
 async def server_stop(app, loop):
-    """Sends a message to the webhook channel when server stops"""
+    """Sends a message to the webhook channel when server stops."""
     em = Embed(color=0xe67e22)
     em.set_footer('Host: {}'.format(socket.gethostname()))
-    em.set_author('[INFO] Server Stopped')
+    em.description = '[INFO] Server Stopped'
 
-    await app.webhook.send(embeds=em)
+    await app.webhook.send(embed=em)
     await app.session.close()
 
 
 @app.get('/')
 async def index(request):
-    return response.text('hello')
+    return response.text("To send a message, go to "
+                         "0.0.0.0:8000/message/?msg='insert message here'.")
 
 
 @app.get('/message')
 async def message(request):
-    """?msg=your message goes here"""
-    msg = request.raw_args.get('msg')
+    """
+    To send a message, go to 0.0.0.0:8000/message/?msg='insert message here'.
+    """
+
+    msg = request.get('msg')
+    if msg is None:
+        return request.text("To send a message, go to 0.0.0.0:8000/"
+                            "message/?msg='insert message here'.")
     await app.webhook.send(msg)
-    return response.json({'msg': msg})
+    return response.text("Send.")
 
 if __name__ == "__main__":
-    app.run()
+    # visit 0.0.0.0:8000/ from your browser
+    app.run(host="0.0.0.0", port=8000)

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -1,7 +1,8 @@
-import os
 from dhooks import Embed, Webhook
 
-webhook_url = os.getenv('webhook_url')
+###
+webhook_url = "<INSERT WEBHOOK URL HERE>"
+###
 
 client = Webhook(webhook_url)
 
@@ -11,8 +12,13 @@ client = Webhook(webhook_url)
 em1 = Embed()
 
 em1.color = 0x00FF00  # colors should be a hexadecimal value
-em1.description = "this description supports \
-[named links](https://discordapp.com) as well. ```\nyes, even code blocks```"
+em1.description = """this description supports 
+[named links](https://discordapp.com) as well. 
+
+``` \n
+yes, even code blocks```
+"""
+
 em1.timestamp = "2018-04-30T05:34:26-07:00"
 
 em1.set_author(

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -12,8 +12,8 @@ client = Webhook(webhook_url)
 em1 = Embed()
 
 em1.color = 0x00FF00  # colors should be a hexadecimal value
-em1.description = """this description supports 
-[named links](https://discordapp.com) as well. 
+em1.description = """This description supports
+[named links](https://discordapp.com) as well.
 
 ``` \n
 yes, even code blocks```

--- a/examples/message.py
+++ b/examples/message.py
@@ -1,5 +1,10 @@
 from dhooks import Webhook
 
-hook = Webhook('WEBHOOK_URL')
 
+###
+webhook_url = "<INSERT WEBHOOK URL HERE>"
+###
+
+
+hook = Webhook(webhook_url)
 hook.send("Hello there! I'm a webhook :open_mouth:")

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
             'tox-travis',
             'flake8',
             'python-dotenv'
+        },
+        'examples': {
+            'sanic'
         }
     },
     python_requires='>=3.5',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,18 @@ setup(
     long_description_content_type='text/markdown',
     license='MIT',
     keywords=['discord', 'webhooks', 'discordwebhooks', 'discordhooks'],
-    install_requires=['aiohttp', 'requests==2.20.1'],
+    install_requires=['aiohttp', 'requests'],
+    extras_require={
+        'docs': {
+            'sphinx_rtd_theme',
+            'sphinx'
+        },
+        'tests': {
+            'tox-travis',
+            'flake8',
+            'python-dotenv'
+        }
+    },
     python_requires='>=3.5',
     url='https://github.com/4rqm/dhooks/',
     project_urls={

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,0 @@
-tox-travis
-flake8

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -7,14 +7,14 @@ import dhooks
 from io import BytesIO
 import asyncio
 
-try:
-    from dotenv import load_dotenv, find_dotenv
-    load_dotenv(find_dotenv())
-except ImportError:
-    load_dotenv = find_dotenv = None
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
 
 
-REAL_URL = os.getenv('TEST_WEBHOOK_URL')
+REAL_URL = os.getenv('TEST_WEBHOOK_URL', None)
+if REAL_URL is None:
+    raise ValueError("TEST_WEBHOOK_URL environment variable not found.")
+
 FAKE_URL = 'https://discordapp.com/api/webhooks/12345678901234567890/' \
            'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk'
 

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -5,14 +5,14 @@ import os
 import dhooks
 from io import BytesIO
 
-try:
-    from dotenv import load_dotenv, find_dotenv
-    load_dotenv(find_dotenv())
-except ImportError:
-    load_dotenv = find_dotenv = None
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
 
 
-REAL_URL = os.getenv('TEST_WEBHOOK_URL')
+REAL_URL = os.getenv('TEST_WEBHOOK_URL', None)
+if REAL_URL is None:
+    raise ValueError("TEST_WEBHOOK_URL environment variable not found.")
+
 FAKE_URL = 'https://discordapp.com/api/webhooks/12345678901234567890/' \
            'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk'
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ ignore = W293  # empty lines for readability improvments in doc-strings
 envlist = py35,py36,py37
 
 [testenv]
-install_command = python -m pip install .[tests]
+deps = .[tests]
 changedir = tests
 sitepackages = true
 commands = python -m unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [flake8]
 exclude = __init__.py
-ignore = W293  # empty lines for readability improvments in rst docstrings
+ignore = W293  # empty lines for readability improvments in doc-strings
 
 [tox]
 envlist = py35,py36,py37
 
 [testenv]
-deps = python-dotenv
+install_command = python -m pip install .[tests]
 changedir = tests
 sitepackages = true
 commands = python -m unittest


### PR DESCRIPTION
This pull request placed all requirements into `setup.py`, changed `.tox`, `.travis.yml`, and `.readthedocs.yml` to reflect the change. (I tested everything on an isolated environment, it should run smoothly as before)

    install_requires=['aiohttp', 'requests'],
    extras_require={
        'docs': {
            'sphinx_rtd_theme',
            'sphinx'
        },
        'tests': {
            'tox-travis',
            'flake8',
            'python-dotenv'
        },
        'examples': {
            'sanic'
        }
    }

Other changes:

  - Added a "docs" badge in `README.md`. 
  - Changed main installation method from pipenv to pip. 
    - Since pipenv can install any package that pip can install. If someone wants to use pipenv, they can use it in their discretion. 
    - I don't believe we need to suggest pipenv over pip.
  - Added git cloning example in `README.md`.

## Note:
There are no breaking change in this PR.