### PR TITLE
Removed space after line continuation.

### DIFF
--- a/dhooks/client.py
+++ b/dhooks/client.py
@@ -115,7 +115,7 @@ class Webhook:
         The id of the channel the webhook sends messages to.
 
     """  # noqa: W605
-    URL_REGEX = r'^(?:https?://)?((canary|ptb)\.)?discordapp\.com/api/webhooks/' \ 
+    URL_REGEX = r'^(?:https?://)?((canary|ptb)\.)?discordapp\.com/api/webhooks/' \
                 r'(?P<id>[0-9]+)/(?P<token>[A-Za-z0-9\.\-\_]+)/?$'
     ENDPOINT = 'https://discordapp.com/api/webhooks/{id}/{token}'
     CDN = r'https://cdn.discordapp.com/avatars/' \


### PR DESCRIPTION
The space created this error on import: 

 Traceback (most recent call last):
  File "a1.py", line 1, in <module>
    from dhooks import Webhook
  File "/code/dev/async/env/lib/python3.7/site-packages/dhooks/__init__.py", line 1, in <module>
    from .client import Webhook
  File "/code/dev/async/env/lib/python3.7/site-packages/dhooks/client.py", line 118
    URL_REGEX = r'^(?:https?://)?((canary|ptb)\.)?discordapp\.com/api/webhooks/' \