### PR TITLE
Move all but cdn to discord.com

### DIFF
--- a/dhooks/client.py
+++ b/dhooks/client.py
@@ -29,7 +29,7 @@ class Webhook:
         Note: the URL should contain the :attr:`id` and :attr:`token`
         of the webhook in the form of: ::
         
-            https://discordapp.com/api/webhooks/webhooks/{id}/{token}
+            https://discord.com/api/webhooks/webhooks/{id}/{token}
             
         .. warning::
             If you don't provide :attr:`url`, you must provide both :attr:`id`
@@ -103,7 +103,7 @@ class Webhook:
         :meth:`modify` or directly through discord server settings.
 
     default_avatar: str
-        The `avatar string <https://discordapp.com/developers/docs/re
+        The `avatar string <https://discord.com/developers/docs/re
         sources/user#avatar-data>`_ of the webhook.
 
     guild_id: int
@@ -115,9 +115,9 @@ class Webhook:
         The id of the channel the webhook sends messages to.
 
     """  # noqa: W605
-    URL_REGEX = r'^(?:https?://)?((canary|ptb)\.)?discordapp\.com/api/webhooks/' \
+    URL_REGEX = r'^(?:https?://)?((canary|ptb)\.)?discord\.com/api/webhooks/' \
                 r'(?P<id>[0-9]+)/(?P<token>[A-Za-z0-9\.\-\_]+)/?$'
-    ENDPOINT = 'https://discordapp.com/api/webhooks/{id}/{token}'
+    ENDPOINT = 'https://discord.com/api/webhooks/{id}/{token}'
     CDN = r'https://cdn.discordapp.com/avatars/' \
           r'{0.id}/{0.default_avatar}.{1}?size={2}'
 

--- a/examples/embed.py
+++ b/examples/embed.py
@@ -13,7 +13,7 @@ em1 = Embed()
 
 em1.color = 0x00FF00  # colors should be a hexadecimal value
 em1.description = """This description supports
-[named links](https://discordapp.com) as well.
+[named links](https://discord.com) as well.
 
 ``` \n
 yes, even code blocks```
@@ -24,12 +24,12 @@ em1.timestamp = "2018-04-30T05:34:26-07:00"
 em1.set_author(
     name='Author Goes Here',
     icon_url='https://i.imgur.com/rdm3W9t.png',
-    url='https://discordapp.com/'
+    url='https://discord.com/'
 )
 
 em1.set_title(
     title='title ~~(did you know you can have markdown here too?)~~',
-    url='https://discordapp.com/'
+    url='https://discord.com/'
 )
 
 em1.add_field(

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -1,1 +1,1 @@
-TEST_WEBHOOK_URL = https://discordapp.com/api/webhooks/{id}/{token}
+TEST_WEBHOOK_URL = https://discord.com/api/webhooks/{id}/{token}

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -15,10 +15,10 @@ REAL_URL = os.getenv('TEST_WEBHOOK_URL', None)
 if REAL_URL is None:
     raise ValueError("TEST_WEBHOOK_URL environment variable not found.")
 
-FAKE_URL = 'https://discordapp.com/api/webhooks/12345678901234567890/' \
+FAKE_URL = 'https://discord.com/api/webhooks/12345678901234567890/' \
            'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk'
 
-MALFORMED_URL = 'https://discordapp.com/api/webhooks/bob'
+MALFORMED_URL = 'https://discord.com/api/webhooks/bob'
 
 
 class TestBlockingClient(unittest.TestCase):

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -13,10 +13,10 @@ REAL_URL = os.getenv('TEST_WEBHOOK_URL', None)
 if REAL_URL is None:
     raise ValueError("TEST_WEBHOOK_URL environment variable not found.")
 
-FAKE_URL = 'https://discordapp.com/api/webhooks/12345678901234567890/' \
+FAKE_URL = 'https://discord.com/api/webhooks/12345678901234567890/' \
            'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk'
 
-MALFORMED_URL = 'https://discordapp.com/api/webhooks/bob'
+MALFORMED_URL = 'https://discord.com/api/webhooks/bob'
 
 
 class TestBlockingClient(unittest.TestCase):


### PR DESCRIPTION
Discord tweeted some time ago that they were going to be keeping cdn.discordapp.com for the foreseeable future, and it currently shows as there is no DNS record for cdn.discord.com.