### PR TITLE
fix: flip logic

### DIFF
--- a/dhooks/client.py
+++ b/dhooks/client.py
@@ -134,7 +134,7 @@ class Webhook:
         if not self.url and (self.id == -1 or not self.token):
             raise ValueError("Either url, or id and token must be provided.")
 
-        elif not self.url and (self.id or self.token):
+        elif self.url and (self.id or self.token):
             raise ValueError("url and (id or token) must not be both "
                              "provided.")
 

--- a/dhooks/client.py
+++ b/dhooks/client.py
@@ -134,7 +134,7 @@ class Webhook:
         if not self.url and (self.id == -1 or not self.token):
             raise ValueError("Either url, or id and token must be provided.")
 
-        elif self.url and (self.id or self.token):
+        elif self.url and (self.id != -1 or self.token):
             raise ValueError("url and (id or token) must not be both "
                              "provided.")
 


### PR DESCRIPTION
so first off, the if statement above this one checks if neither a url or id and token are provided. 
this if is meant to check if *both* a url and an id and token are provided, but this `not` messes this up.
instead, what this does is block you from using and id and token by raising a `ValueError` if you do so.

Atleast that is my interpretation, let me know if i'm thinking about this wrong.